### PR TITLE
Fixed msg and proc snippet arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Have fun!
 
 ### msg
 ```
-<xsl:message${1: terminate="${2"}>${0}</xsl:message>
+<xsl:message${1: terminate="${2}"}>${0}</xsl:message>
 ```
 
 ### nam
@@ -203,7 +203,7 @@ Have fun!
 
 ### proc
 ```
-<xsl:processing-instruction name="{$1}">${0}</xsl:processing-instruction>
+<xsl:processing-instruction name="${1}">${0}</xsl:processing-instruction>
 ```
 
 ### scr

--- a/message.sublime-snippet
+++ b/message.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-  <content><![CDATA[<xsl:message${1: terminate="${2"}>${0}</xsl:message>]]></content>
+  <content><![CDATA[<xsl:message${1: terminate="${2}"}>${0}</xsl:message>]]></content>
   <tabTrigger>msg</tabTrigger>
   <scope>text.xml.xsl</scope>
   <description>message</description>

--- a/processing-instruction.sublime-snippet
+++ b/processing-instruction.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-  <content><![CDATA[<xsl:processing-instruction name="{$1}">${0}</xsl:processing-instruction>]]></content>
+  <content><![CDATA[<xsl:processing-instruction name="${1}">${0}</xsl:processing-instruction>]]></content>
   <tabTrigger>proc</tabTrigger>
   <scope>text.xml.xsl</scope>
   <description>processing-instruction</description>


### PR DESCRIPTION
- The `msg` snippet didn't output anything because the 2nd parameter wasn't closed.
- The `proc` snippet worked, but showed the 1st parameter braces in the output, as the `$` was inside them.
